### PR TITLE
Add tap to copy IP address button to connected devices list

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="hotspot_not_enabled">Hotspot is not yet enabled.</string>
     <string name="hotspot_enable_action">ENABLE</string>
     <string name="edit_button">Edit</string>
+    <string name="copy_button">Copy</string>
     <!-- dev.shadoe.delta.debug.DebugActivity -->
     <string name="debug_title">Debug screen</string>
     <string name="debug_trigger_crash">Trigger a crash</string>


### PR DESCRIPTION
### Summary

Replace the plain text client ip in the ConnectedDevicesList with a clickable TextButton that copies the IP address.

I've tried to be consistent with the project's style (using the default TextButton, using `gradlew spotlessApply` etc.), but please let me know what you think. I'm more than happy to make changes when needed.

### Related issue(s)

Fixes: #63

### Screenshot

<img src="https://github.com/user-attachments/assets/74989f32-7e01-4918-bb90-ae062f376312" width="30%" />
