### PR TITLE
Fix AP status check on some devices running Android >= 15

### DIFF
--- a/data/src/main/kotlin/dev/shadoe/delta/data/softap/callbacks/SoftApCallback.kt
+++ b/data/src/main/kotlin/dev/shadoe/delta/data/softap/callbacks/SoftApCallback.kt
@@ -33,11 +33,13 @@ internal class SoftApCallback(
     Refine.unsafeCast<TetheringManagerHidden.TetheringRequest>(
         state.tetheringRequest
       )
-      .parcel
+      ?.parcel
       ?.tetheringType
       ?.let { it == TETHERING_WIFI }
-      .takeIf { it != false }
-      ?.let { tetheringEventListener.onEnabledStateChanged(state.state) }
+      .let {
+        if (it != false)
+          tetheringEventListener.onEnabledStateChanged(state.state)
+      }
   }
 
   @Deprecated("Removed in API 35")


### PR DESCRIPTION
### Summary

In some cases (Android 15), the Framework doesn't provide any `tetheringRequest`. This PR adds a null check for this, along with a fix that ignores the check for `TETHERING_WIFI` when the `tetheringRequest` doesn't exist. This check is strictly not needed, as `WifiManager` only fires events for WiFi tethering, but there's no reason for removing the check entirely so I just kept it there.

### Related issue(s)

Fixes: #65

### Screenshot

![image](https://github.com/user-attachments/assets/20327990-e60e-4a10-9400-b8433f2e6c64)
