### PR TITLE
feat: show presets on the main screen

### DIFF
--- a/app/src/main/kotlin/dev/shadoe/delta/control/ControlScreen.kt
+++ b/app/src/main/kotlin/dev/shadoe/delta/control/ControlScreen.kt
@@ -118,7 +118,7 @@ fun ControlScreen(
         applyPreset = {
           vm.applyPreset(it)
           onShowSnackbar(presetAppliedSnackbar)
-        }
+        },
       )
     }
     if (supportsBlocklist) {

--- a/app/src/main/kotlin/dev/shadoe/delta/control/ControlScreen.kt
+++ b/app/src/main/kotlin/dev/shadoe/delta/control/ControlScreen.kt
@@ -28,6 +28,7 @@ import dev.shadoe.delta.control.components.SoftApControl
 import dev.shadoe.delta.control.components.SoftApControlViewModel
 import dev.shadoe.delta.control.components.blocklistComponent
 import dev.shadoe.delta.control.components.connectedClientsList
+import dev.shadoe.delta.control.components.presetsComponent
 
 @Composable
 fun ControlScreen(
@@ -46,6 +47,7 @@ fun ControlScreen(
   val tetheredClients by vm.connectedClients.collectAsState(listOf())
   val blockedClients by vm.blockedClients.collectAsState(listOf())
   val supportsBlocklist by vm.supportsBlocklist.collectAsState(false)
+  val presets by vm.presets.collectAsState(listOf())
 
   val featureNotSupportedSnackbar =
     object : SnackbarVisuals {
@@ -64,6 +66,13 @@ fun ControlScreen(
   val clientsUnblockedSnackbar =
     object : SnackbarVisuals {
       override val message = stringResource(R.string.blocklist_unblocked)
+      override val duration = SnackbarDuration.Short
+      override val withDismissAction = true
+      override val actionLabel = null
+    }
+  val presetAppliedSnackbar =
+    object : SnackbarVisuals {
+      override val message = stringResource(R.string.preset_applied)
       override val duration = SnackbarDuration.Short
       override val withDismissAction = true
       override val actionLabel = null
@@ -101,6 +110,15 @@ fun ControlScreen(
               onShowSnackbar(clientsBlockedSnackbar)
             },
           ),
+      )
+    }
+    if (enabledState == SoftApEnabledState.WIFI_AP_STATE_DISABLED) {
+      presetsComponent(
+        presets,
+        applyPreset = {
+          vm.applyPreset(it)
+          onShowSnackbar(presetAppliedSnackbar)
+        }
       )
     }
     if (supportsBlocklist) {

--- a/app/src/main/kotlin/dev/shadoe/delta/control/ControlViewModel.kt
+++ b/app/src/main/kotlin/dev/shadoe/delta/control/ControlViewModel.kt
@@ -43,19 +43,21 @@ constructor(
     softApBlocklistManager.unblockDevices(devices)
 
   fun applyPreset(preset: Preset) =
-    softApController.updateSoftApConfiguration(preset.run {
-      SoftApConfiguration(
-        ssid = ssid,
-        passphrase = passphrase,
-        securityType = securityType,
-        macRandomizationSetting = macRandomizationSetting,
-        isHidden = isHidden,
-        speedType = speedType,
-        blockedDevices = blockedDevices,
-        allowedClients = allowedClients,
-        isAutoShutdownEnabled = isAutoShutdownEnabled,
-        autoShutdownTimeout = autoShutdownTimeout,
-        maxClientLimit = maxClientLimit,
-      )
-    })
+    softApController.updateSoftApConfiguration(
+      preset.run {
+        SoftApConfiguration(
+          ssid = ssid,
+          passphrase = passphrase,
+          securityType = securityType,
+          macRandomizationSetting = macRandomizationSetting,
+          isHidden = isHidden,
+          speedType = speedType,
+          blockedDevices = blockedDevices,
+          allowedClients = allowedClients,
+          isAutoShutdownEnabled = isAutoShutdownEnabled,
+          autoShutdownTimeout = autoShutdownTimeout,
+          maxClientLimit = maxClientLimit,
+        )
+      }
+    )
 }

--- a/app/src/main/kotlin/dev/shadoe/delta/control/ControlViewModel.kt
+++ b/app/src/main/kotlin/dev/shadoe/delta/control/ControlViewModel.kt
@@ -3,7 +3,11 @@ package dev.shadoe.delta.control
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.shadoe.delta.api.ACLDevice
+import dev.shadoe.delta.api.SoftApConfiguration
+import dev.shadoe.delta.data.database.dao.PresetDao
+import dev.shadoe.delta.data.database.models.Preset
 import dev.shadoe.delta.data.softap.SoftApBlocklistManager
+import dev.shadoe.delta.data.softap.SoftApController
 import dev.shadoe.delta.data.softap.SoftApStateStore
 import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -14,7 +18,9 @@ class ControlViewModel
 @Inject
 constructor(
   state: SoftApStateStore,
+  presetDao: PresetDao,
   private val softApBlocklistManager: SoftApBlocklistManager,
+  private val softApController: SoftApController,
 ) : ViewModel() {
   @OptIn(ExperimentalCoroutinesApi::class)
   val enabledState = state.status.mapLatest { it.enabledState }
@@ -26,6 +32,8 @@ constructor(
   val supportsBlocklist =
     state.status.mapLatest { it.capabilities.clientForceDisconnectSupported }
 
+  val presets = presetDao.observePresets()
+
   val blockedClients = softApBlocklistManager.blockedClients
 
   fun blockDevices(devices: Iterable<ACLDevice>) =
@@ -33,4 +41,21 @@ constructor(
 
   fun unblockDevices(devices: Iterable<ACLDevice>) =
     softApBlocklistManager.unblockDevices(devices)
+
+  fun applyPreset(preset: Preset) =
+    softApController.updateSoftApConfiguration(preset.run {
+      SoftApConfiguration(
+        ssid = ssid,
+        passphrase = passphrase,
+        securityType = securityType,
+        macRandomizationSetting = macRandomizationSetting,
+        isHidden = isHidden,
+        speedType = speedType,
+        blockedDevices = blockedDevices,
+        allowedClients = allowedClients,
+        isAutoShutdownEnabled = isAutoShutdownEnabled,
+        autoShutdownTimeout = autoShutdownTimeout,
+        maxClientLimit = maxClientLimit,
+      )
+    })
 }

--- a/app/src/main/kotlin/dev/shadoe/delta/control/components/PresetComponent.kt
+++ b/app/src/main/kotlin/dev/shadoe/delta/control/components/PresetComponent.kt
@@ -1,0 +1,42 @@
+package dev.shadoe.delta.control.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.SaveAlt
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.shadoe.delta.R
+
+@Composable
+fun PresetComponent(
+  presetName: String,
+  applyPreset: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier =
+      modifier.then(Modifier.padding(horizontal = 16.dp, vertical = 4.dp)),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(modifier = Modifier.weight(1f)) {
+      Text(text = presetName)
+    }
+    Row {
+      IconButton(onClick = applyPreset) {
+        Icon(
+          imageVector = Icons.Rounded.SaveAlt,
+          contentDescription =
+            stringResource(R.string.preset_apply_button),
+        )
+      }
+    }
+  }
+}

--- a/app/src/main/kotlin/dev/shadoe/delta/control/components/PresetComponent.kt
+++ b/app/src/main/kotlin/dev/shadoe/delta/control/components/PresetComponent.kt
@@ -26,15 +26,12 @@ fun PresetComponent(
       modifier.then(Modifier.padding(horizontal = 16.dp, vertical = 4.dp)),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    Column(modifier = Modifier.weight(1f)) {
-      Text(text = presetName)
-    }
+    Column(modifier = Modifier.weight(1f)) { Text(text = presetName) }
     Row {
       IconButton(onClick = applyPreset) {
         Icon(
           imageVector = Icons.Rounded.SaveAlt,
-          contentDescription =
-            stringResource(R.string.preset_apply_button),
+          contentDescription = stringResource(R.string.preset_apply_button),
         )
       }
     }

--- a/app/src/main/kotlin/dev/shadoe/delta/control/components/PresetsComponent.kt
+++ b/app/src/main/kotlin/dev/shadoe/delta/control/components/PresetsComponent.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.unit.dp
 import dev.shadoe.delta.R
 import dev.shadoe.delta.data.database.models.Preset
 
-
 internal fun LazyListScope.presetsComponent(
   presets: List<Preset>,
   applyPreset: (Preset) -> Unit,
@@ -45,10 +44,7 @@ internal fun LazyListScope.presetsComponent(
       horizontalArrangement = Arrangement.SpaceBetween,
       verticalAlignment = Alignment.CenterVertically,
     ) {
-      PresetComponent(
-        it.presetName,
-        applyPreset = { applyPreset(it) }
-      )
+      PresetComponent(it.presetName, applyPreset = { applyPreset(it) })
     }
   }
 }

--- a/app/src/main/kotlin/dev/shadoe/delta/control/components/PresetsComponent.kt
+++ b/app/src/main/kotlin/dev/shadoe/delta/control/components/PresetsComponent.kt
@@ -1,0 +1,54 @@
+package dev.shadoe.delta.control.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import dev.shadoe.delta.R
+import dev.shadoe.delta.data.database.models.Preset
+
+
+internal fun LazyListScope.presetsComponent(
+  presets: List<Preset>,
+  applyPreset: (Preset) -> Unit,
+) {
+  item {
+    Text(
+      text = stringResource(R.string.presets_setting),
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      style = MaterialTheme.typography.titleLarge,
+      modifier = Modifier.padding(16.dp),
+    )
+  }
+  if (presets.isEmpty()) {
+    item {
+      Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(text = stringResource(R.string.presets_none_saved))
+      }
+    }
+  }
+  items(presets) {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      PresetComponent(
+        it.presetName,
+        applyPreset = { applyPreset(it) }
+      )
+    }
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -215,4 +215,5 @@
     <string name="shizuku_setup_not_running">Not running.</string>
     <string name="shizuku_setup_not_connected">Not connected.</string>
     <string name="shizuku_setup_connected">Connected ✅</string>
+    <string name="preset_applied">Preset applied.</string>
 </resources>


### PR DESCRIPTION
Hey! Thanks for your work on this app!

### Summary

* A new component that shows presets on the main screen.
* Snackbar message on apply
* New `stringResource(R.string.preset_applied)` (I haven't found a string to reuse, so had to add a new one :frowning_face: )

<details>
<summary>Screenshot</summary>
<img height="512" alt="Screenshot_20260106-093641_delta (debug)" src="https://github.com/user-attachments/assets/2fd9e68d-641b-4f6b-ae4d-7ae55b0c3c3d" />
</details>

### Related issue(s)
None.
<!--
List the issues that are linked to this PR; a PR should at least be linked to
one issue in the repo, especially if it is a new feature to be added because
the implementation, requirement and other aspects can be discussed beforehand.

PRs without a link to any issue will be handled on a case by case basis, mostly
resulting in the PR being closed. You are free to open a PR after creating an
issue and discussing though.
-->
